### PR TITLE
delete get_associations method

### DIFF
--- a/BUML/metamodel/structural/structural.py
+++ b/BUML/metamodel/structural/structural.py
@@ -500,9 +500,3 @@ class DomainModel(NamedElement):
     
     def get_class_by_name(self, class_name: str) -> Class:
         return next((element for element in self.types if isinstance(element, Class) and element.name == class_name), None)
-
-    def get_associations(self) -> set[Association]:
-        return {element for element in self.elements if isinstance(element, Association)}
-
-    def get_packages(self) -> set[Package]:
-        return {element for element in self.elements if isinstance(element, Package)}


### PR DESCRIPTION
#4 solved

To get the list of associations of a BUML model, use the method `associations`