### PR TITLE
Add @property decorator to associations and generalizations methods

### DIFF
--- a/src/BUML/metamodel/structural/structural.py
+++ b/src/BUML/metamodel/structural/structural.py
@@ -213,6 +213,7 @@ class Class(Type):
     def is_abstract(self, is_abstract: bool):
         self.__is_abstract = is_abstract
 
+    @property
     def associations(self):
         return self.__associations
     
@@ -222,6 +223,7 @@ class Class(Type):
     def _delete_association(self, association):
         self.__associations.discard(association)
 
+    @property
     def generalizations(self):
         return self.__generalizations
     

--- a/tests/structural/test_structural.py
+++ b/tests/structural/test_structural.py
@@ -92,6 +92,7 @@ def test_association_initialization():
     assert len(association.ends) == 2
     assert aend1 in association.ends
     assert aend1.owner == association
+    assert class1.associations == {association}
 
 # Testing the creation of a binary association cannot have more than two ends
 def test_binary_association():
@@ -122,6 +123,7 @@ def test_generalization_initialization():
     generalization: Generalization = Generalization(general=class1, specific=class2)
     assert generalization.general == class1
     assert generalization.specific == class2
+    assert class2.generalizations == {generalization}
 
 def test_no_generalization_loop():
     with pytest.raises(ValueError) as excinfo:


### PR DESCRIPTION
The associations and generalizations in which a class is involved can be obtained as follows:

`class1.associations`
`class1.generalizations`